### PR TITLE
[hotfix] webpacker:compileが実行できない不具合を棚上げ

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -49,7 +49,7 @@ default: &default
 
 development:
   <<: *default
-  compile: true
+  compile: false
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:
@@ -59,7 +59,7 @@ development:
     public: localhost:3035
     hmr: false
     # Inline should be set to true if using HMR
-    inline: true
+    inline: false
     overlay: true
     compress: true
     disable_host_check: true


### PR DESCRIPTION
close #95

CIとnode modulesのバージョンが乖離しすぎて、依存関係を解決することが困難だと判断

本PRでは現在CIが動いていることだけ確認する

## TBD
1. CSSに影響されない範囲でまずはSystem specを完成させる  
  Javascriptを使用している機能がどの程度あったかしっかり覚えてないが、数は多くないはず
2. 早急にRails 7.0までバージョンアップ  
  Rails 7.0では、Webpackerの代わりにjsbundling-railsとcssbundling-railsが推奨（Rails 7.1ではWebpackerが非推奨）  
  **→Webpackerの問題は棚上げして、Rails 7.0までバージョンを上げてしまう**