### PR TITLE
spec/support/page_objects/components/header.rb追加

### DIFF
--- a/spec/support/page_objects/components/header.rb
+++ b/spec/support/page_objects/components/header.rb
@@ -3,8 +3,12 @@
 class Header
   include Capybara::DSL
 
+  def initialize(user_name = 'Test User')
+    @user_name = user_name
+  end
+
   def goto_user_edit
-    find('.nav-link', text: current_user_name).click
+    find('.header_menu_user .nav-link', text: @user_name).click
   end
 
   def goto_home
@@ -17,11 +21,5 @@ class Header
 
   def sign_out
     find('.header_menu_inner .nav-link', text: 'Sign out').click
-  end
-
-  private
-
-  def current_user_name
-    current_user&.name || 'Test User'
   end
 end


### PR DESCRIPTION
resolve #105 

グローバルヘッダーメニューの共通処理

CSSセレクタの参照先:
`app/views/partial/_header.html.erb`