### PR TITLE
spec/support/page_objects/pages/registration_page.rb追加

### DIFF
--- a/spec/support/page_objects/pages/registration_page.rb
+++ b/spec/support/page_objects/pages/registration_page.rb
@@ -58,6 +58,6 @@ class RegistrationPage
 
   def have_flash?(text)
     # TODO: [data-testid="flash"]
-    page.has_selector?('alert.alert-info', text: text)
+    page.has_selector?('.alert.alert-info', text: text)
   end
 end


### PR DESCRIPTION
resolve #122

サインアップ時のユーザー登録用page object作成

CSSセレクタの参照先:
`app/views/devise/registrations/new.html.erb`
`app/views/layouts/application.html.erb`