### PR TITLE
minimum_coverageを有効化

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.start 'rails' do
     add_filter %w[/config/ /vendor/ /spec/ /test/]
-    # minimum_coverage 60
+    minimum_coverage 80
   end
 end
 


### PR DESCRIPTION
resolve #65 

RSpecの整備が進んでカバレッジが80%を超えたので`minimum_coverage`を有効化