### PR TITLE
spec/system/lists/create_spec.rbにテストケース追加

### DIFF
--- a/spec/system/lists/create_spec.rb
+++ b/spec/system/lists/create_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe 'Lists: Create', type: :system do
       within('.listWrapper') do
         # TODO: [data-testid="list-title"]
         expect(page).to have_selector('.list_header_title', text: 'Todo')
+        # NOTE: カード作成リンクが表示されていることも確認
+        expect(page).to have_selector('.addCard_link', text: 'Add a card...')
       end
     end
   end


### PR DESCRIPTION
#110 

リストを作成すると、カード作成ページへのリンクが表示されることを確認するテストケースを追加