### PR TITLE
[Docker] Debian Bullseyeの署名鍵問題を解消

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,6 @@ RUN set -eux; \
 RUN set -eux; \
   apt-get update -qq && apt-get install -y --no-install-recommends \
     curl \
-    ca-certificates \
-    gnupg \
     wget \
     unzip \
     fonts-liberation \


### PR DESCRIPTION
resolve #158 

イメージをビルドできなくなっていたのでDockerfileを修正