### PR TITLE
chore: Rails6.1更新時のhotfixを削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,6 @@ jobs:
       - name: ERB Lint
         if: hashFiles('**/*.erb') != ''
         run: bundle exec erblint --lint-all --format compact
-        # hotfix: bundle updateに伴うlogger読み込みエラー対策
-        env:
-          RUBYOPT: '-rbundler/setup -rlogger'
 
       - name: ESLint
         if: ${{ hashFiles('app/javascript/**/*.{js,jsx}') != '' }}

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,5 +1,4 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.
-require "logger"
 require "bootsnap/setup" # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
fix #161 

Rails6.1でgemを更新した際に入れたhotfixが、Rails7.1までアップグレードしたことで必要なくなったので削除