### PR TITLE
chore: spec/factories/users.rbのファイル名変更

### DIFF
--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,8 +1,0 @@
-FactoryBot.define do
-  factory :user do
-    name { Faker::Internet.unique.username(specifier: 2..20) }
-    email { Faker::Internet.unique.email }
-    password { 'password' }
-    password_confirmation { 'password' }
-  end
-end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  email                  :string(255)      default(""), not null
+#  encrypted_password     :string(255)      default(""), not null
+#  name                   :string(255)      default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string(255)
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+FactoryBot.define do
+  factory :user do
+    name { Faker::Internet.unique.username(specifier: 2..20) }
+    email { Faker::Internet.unique.email }
+    password { 'password' }
+    password_confirmation { 'password' }
+  end
+end


### PR DESCRIPTION
#218 の追加対応

annotateを導入したことで spec/factories/users.rb のファイル名が命名規則に従ってないことに気付いたので修正