### PR TITLE
chore: set selenium platform to suppress ARM warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       SELENIUM_HOST: selenium
 
   selenium:
+    # FIXME: arm64環境のイメージに更新するまでplatformを指定して警告を回避
+    platform: linux/amd64
     image: selenium/standalone-chrome:3.141.59
     shm_size: 2gb
     ports:


### PR DESCRIPTION
fix #264 

> [!NOTE]
> とりあえずwarningを抑制するための設定を追加しておくが、イメージも古いので新しくしたい